### PR TITLE
fix: support removed operations in `definitionToEndpoint`

### DIFF
--- a/lib/definition-to-endpoint.js
+++ b/lib/definition-to-endpoint.js
@@ -233,6 +233,8 @@ function definitionToEndpoint({ method: rawMethod, url }, definition) {
     }
   }
 
+  const x_github = definition["x-github"] || {};
+
   const endpoint = {
     id,
     scope,
@@ -244,12 +246,12 @@ function definitionToEndpoint({ method: rawMethod, url }, definition) {
     headers,
     documentationUrl: definition.externalDocs.url,
     isDeprecated: !!definition.deprecated,
-    deprecationDate: definition["x-github"].deprecationDate,
-    removalDate: definition["x-github"].removalDate,
-    isEnabledForApps: definition["x-github"].enabledForApps,
-    isGithubCloudOnly: definition["x-github"].githubCloudOnly,
-    triggersNotification: definition["x-github"].triggersNotification,
-    previews: definition["x-github"].previews,
+    deprecationDate: x_github.deprecationDate,
+    removalDate: x_github.removalDate,
+    isEnabledForApps: x_github.enabledForApps,
+    isGithubCloudOnly: x_github.githubCloudOnly,
+    triggersNotification: x_github.triggersNotification,
+    previews: x_github.previews,
     responses,
     changes: findBreakingChanges({ id, parameters, definition }),
   };


### PR DESCRIPTION
This repository uses data generated and stored in `octokit/openapi`.

This code in its current state doesn't seem to be compatible with the data which is currently in `octokit/openapi`.

Specifically, where one API version has an operation and another doesn't, then
we add a special operation entry representing the missing operation. This is done in the [`addRemovedOperations` method][1].

When these special operation entries are added, they doesn't have the `X-GitHub` extension data included. Currently, we expect that to be there and blow up if it isn't. This makes the code more tolerant.

This issue is manifested when you try to run `VERSION=5.12.0 npm run update-endpoints` in `octokit/plugin-enterprise-server.js`

[1]:
https://github.com/octokit/openapi/blob/65f7b1ce4f0d90fa1db433d7f0904ecd6cc3bdc4/scripts/build.js#L413